### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -26,7 +26,7 @@ class syntax_plugin_flowplayer extends DokuWiki_Syntax_Plugin {
 
     function connectTo($mode) { $this->Lexer->addSpecialPattern('{{flowplayer>.*?}}',$mode,'plugin_flowplayer'); }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $width = 320;
         $height = 240;
         $params['scaling'] = '"fit"';
@@ -49,7 +49,7 @@ class syntax_plugin_flowplayer extends DokuWiki_Syntax_Plugin {
         return array('url' => $url, 'width' => $width, 'height' => $height, 'fid' => uniqid(), 'attr' => $params);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml'){
             $renderer->doc .= '<object type="application/x-shockwave-flash"';
             $renderer->doc .= ' id="fp-'.$data['fid'].'"';


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
